### PR TITLE
Adds various subnets & improves description consistency

### DIFF
--- a/components/chain/subnets.json
+++ b/components/chain/subnets.json
@@ -272,5 +272,59 @@
         "standard": "none"
       }
     ]
+  },
+  {
+    "name": "XANA Subnet",
+    "chain": "XANAchain",
+    "description": "Subnet for XANA, an AI-driven Web3 infrastructure custom-built for the Metaverse.",
+    "isLive": true,
+    "rpc": [
+      "https://mainnet.xana.net/rpc"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "XETA",
+      "symbol": "XETA",
+      "decimals": 18
+    },
+    "projectURL": "https://xana.net/",
+    "shortName": "xana",
+    "chainId": 8888,
+    "networkId": 8888,
+    "explorers": [
+      {
+        "name": "ethernal",
+        "url": "https://avascan.info/blockchain/xana/home",
+        "icon": "ethereum",
+        "standard": "none"
+      }
+    ]
+  },
+  {
+    "name": "UPTN Subnet",
+    "chain": "UPTN",
+    "description": "Subnet for UPTN, a leading data and technology company in South Korea.",
+    "isLive": true,
+    "rpc": [
+      "https://node-api.uptn.io/v1/ext/rpc"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "UPTN",
+      "symbol": "UPTN",
+      "decimals": 18
+    },
+    "projectURL": "https://www.skplanet.com/eng/main",
+    "shortName": "uptn",
+    "chainId": 6119,
+    "networkId": 6119,
+    "explorers": [
+      {
+        "name": "ethernal",
+        "url": "https://avascan.info/blockchain/sk-planet/home",
+        "icon": "ethereum",
+        "standard": "none"
+      }
+    ]
   }
 ]

--- a/components/chain/subnets.json
+++ b/components/chain/subnets.json
@@ -220,7 +220,7 @@
     ]
   },
   {
-    "name": "StepNetwork Subnet",
+    "name": "Step Network Subnet",
     "chain": "StepNetwork",
     "description": "Subnet for Step Network, the blockchain made for humans.",
     "isLive": true,

--- a/components/chain/subnets.json
+++ b/components/chain/subnets.json
@@ -330,7 +330,7 @@
   {
     "name": "UPTN Subnet",
     "chain": "UPTN",
-    "description": "Subnet for UPTN, a leading data and technology company in South Korea.",
+    "description": "Subnet for UPTN, a blockchain made for daily life.",
     "isLive": true,
     "rpc": [
       "https://node-api.uptn.io/v1/ext/rpc"

--- a/components/chain/subnets.json
+++ b/components/chain/subnets.json
@@ -191,5 +191,86 @@
         "standard": "none"
       }
     ]
+  },
+  {
+    "name": "DOS Subnet",
+    "chain": "DOS",
+    "description": "Subnet for DOS, the fastest and zero gas fee blockchain network.",
+    "isLive": true,
+    "rpc": [
+      "https://main.doschain.com"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "DOS",
+      "symbol": "DOS",
+      "decimals": 18
+    },
+    "projectURL": "https://doschain.com/",
+    "shortName": "dos",
+    "chainId": 7979,
+    "networkId": 7979,
+    "explorers": [
+      {
+        "name": "ethernal",
+        "url": "https://avascan.info/blockchain/dos/home",
+        "icon": "ethereum",
+        "standard": "none"
+      }
+    ]
+  },
+  {
+    "name": "StepNetwork Subnet",
+    "chain": "StepNetwork",
+    "description": "Subnet for Step Network, the blockchain made for humans.",
+    "isLive": true,
+    "rpc": [
+      "https://rpc.step.network"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "FITFI",
+      "symbol": "FITFI",
+      "decimals": 18
+    },
+    "projectURL": "https://step.network/",
+    "shortName": "step",
+    "chainId": 1234,
+    "networkId": 1234,
+    "explorers": [
+      {
+        "name": "ethernal",
+        "url": "https://avascan.info/blockchain/stepnetwork/home",
+        "icon": "ethereum",
+        "standard": "none"
+      }
+    ]
+  },
+  {
+    "name": "XPLUS Subnet",
+    "chain": "XPLUS",
+    "description": "Subnet for XPLUS, a sharing economy in Web3.",
+    "isLive": true,
+    "rpc": [
+      "https://xsc-dataseed01.xplus.io"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "XYZ",
+      "symbol": "XYZ",
+      "decimals": 18
+    },
+    "projectURL": "https://www.xplus.com/",
+    "shortName": "xplus",
+    "chainId": 1228,
+    "networkId": 1228,
+    "explorers": [
+      {
+        "name": "ethernal",
+        "url": "https://xplusscan.io/blockchain/xplus/home",
+        "icon": "ethereum",
+        "standard": "none"
+      }
+    ]
   }
 ]

--- a/components/chain/subnets.json
+++ b/components/chain/subnets.json
@@ -164,5 +164,32 @@
         "standard": "none"
       }
     ]
+  },
+  {
+    "name": "MELD Subnet",
+    "chain": "MELD",
+    "description": "Subnet for Mintara, a non-custodial DeFi protocol.",
+    "isLive": true,
+    "rpc": [
+      "https://subnets.avax.network/meld/mainnet/rpc"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "MELD",
+      "symbol": "gMELD",
+      "decimals": 18
+    },
+    "projectURL": "https://www.meld.com/",
+    "shortName": "MELD",
+    "chainId": 333000333,
+    "networkId": 333000333,
+    "explorers": [
+      {
+        "name": "ethernal",
+        "url": "https://avascan.info/blockchain/meld/home",
+        "icon": "ethereum",
+        "standard": "none"
+      }
+    ]
   }
 ]

--- a/components/chain/subnets.json
+++ b/components/chain/subnets.json
@@ -195,7 +195,7 @@
   {
     "name": "DOS Subnet",
     "chain": "DOS",
-    "description": "Subnet for DOS, the fastest and zero gas fee blockchain network.",
+    "description": "Subnet for DOS, the fastest zero gas fee blockchain network, made for building any Web3 product- from gaming & entertainment to finance.",
     "isLive": true,
     "rpc": [
       "https://main.doschain.com"

--- a/components/chain/subnets.json
+++ b/components/chain/subnets.json
@@ -29,7 +29,7 @@
   {
     "name": "DFK Chain Testnet",
     "chain": "DFK",
-    "description": "Test subnet for DefiKingdoms project, a Defi protocol/NFT game running on Avalanche & Klaytn.",
+    "description": "Test subnet for DefiKingdoms project, a DeFi protocol/NFT game running on Avalanche & Klaytn.",
     "isLive": false,
     "rpc": [
       "https://subnets.avax.network/defi-kingdoms/dfk-chain-testnet/rpc"
@@ -168,14 +168,14 @@
   {
     "name": "MELD Subnet",
     "chain": "MELD",
-    "description": "Subnet for Mintara, a non-custodial DeFi protocol.",
+    "description": "Subnet for MELD, a non-custodial DeFi protocol.",
     "isLive": true,
     "rpc": [
       "https://subnets.avax.network/meld/mainnet/rpc"
     ],
     "faucets": [],
     "nativeCurrency": {
-      "name": "MELD",
+      "name": "gMELD",
       "symbol": "gMELD",
       "decimals": 18
     },
@@ -187,6 +187,33 @@
       {
         "name": "ethernal",
         "url": "https://avascan.info/blockchain/meld/home",
+        "icon": "ethereum",
+        "standard": "none"
+      }
+    ]
+  },
+  {
+    "name": "MELD Kanazawa Subnet",
+    "chain": "MELD Kanazawa",
+    "description": "Testnet Subnet for MELD, a non-custodial DeFi protocol.",
+    "isLive": true,
+    "rpc": [
+      "https://subnets.avax.network/meld/testnet/rpc"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "gMELD",
+      "symbol": "gMELD",
+      "decimals": 18
+    },
+    "projectURL": "https://www.meld.com/",
+    "shortName": "MELD",
+    "chainId": 222000222,
+    "networkId": 222000222,
+    "explorers": [
+      {
+        "name": "ethernal",
+        "url": "https://subnets-test.avax.network/meld",
         "icon": "ethereum",
         "standard": "none"
       }

--- a/components/chain/subnets.json
+++ b/components/chain/subnets.json
@@ -196,7 +196,7 @@
     "name": "MELD Kanazawa Subnet",
     "chain": "MELD Kanazawa",
     "description": "Testnet Subnet for MELD, a non-custodial DeFi protocol.",
-    "isLive": true,
+    "isLive": false,
     "rpc": [
       "https://subnets.avax.network/meld/testnet/rpc"
     ],

--- a/components/chain/subnets.json
+++ b/components/chain/subnets.json
@@ -341,7 +341,7 @@
       "symbol": "UPTN",
       "decimals": 18
     },
-    "projectURL": "https://www.skplanet.com/eng/main",
+    "projectURL": "https://www.uptn.io/",
     "shortName": "uptn",
     "chainId": 6119,
     "networkId": 6119,


### PR DESCRIPTION
This PR includes the following subnets:
- [MELD Mainnet](https://avascan.info/blockchain/meld/home) & [Testnet subnet](https://subnets-test.avax.network/meld). Information pulled from #15 ~ JSON made consistent with existing entries.
- [DOS Subnet](https://avascan.info/blockchain/dos/home)
- [Step Network Subnet](https://avascan.info/blockchain/stepnetwork/home) (StepNetwork)
- [XPLUS Subnet](https://avascan.info/blockchain/xplus/home)
- [XANA Subnet](https://avascan.info/blockchain/xana/home)
- [UPTN Subnet](https://explorer.uptn.io/)

Vercel deployment: https://subnetlist-tabasco.vercel.app/